### PR TITLE
Allow Manual Recovery Install Without Root

### DIFF
--- a/src/de/robv/android/xposed/installer/InstallerFragment.java
+++ b/src/de/robv/android/xposed/installer/InstallerFragment.java
@@ -608,8 +608,10 @@ public class InstallerFragment extends Fragment {
 	private boolean install() {
 		final int installMode = getInstallMode();
 
-		if (!startShell())
-			return false;
+		if (installMode != INSTALL_MODE_RECOVERY_MANUAL) {
+			if (!startShell())
+				return false;
+		}
 
 		List<String> messages = new LinkedList<String>();
 		boolean showAlert = true;
@@ -696,7 +698,8 @@ public class InstallerFragment extends Fragment {
 				return false;
 			}
 
-			mRootUtil.executeWithBusybox("sync", messages);
+			if (installMode != INSTALL_MODE_RECOVERY_MANUAL) 
+				mRootUtil.executeWithBusybox("sync", messages);
 
 			showAlert = false;
 			messages.add("");


### PR DESCRIPTION
Adding changes proposed by @jurben (http://forum.xda-developers.com/showpost.php?p=55438345&postcount=8).

This allows for installing Xposed manually without root (but with a custom recovery).

I would very much like this as well and I don't believe that any problems are caused by skipping the sync for a manual install as only copying a single file has occurred.
